### PR TITLE
#168682276: set token expiry timedelta to 24 hours

### DIFF
--- a/api/controllers/user_controller.py
+++ b/api/controllers/user_controller.py
@@ -9,6 +9,7 @@ from flask_jwt_extended import (
     get_jwt_claims
 )
 import jwt
+from datetime import datetime, timedelta
 from decouple import config
 validate = UserValidate()
 class UserController:
@@ -100,7 +101,8 @@ class UserController:
             'username': data['username'],
             'role': role
         }
-        access_token = create_access_token(identity=identity)
+        expires=timedelta(hours=23)
+        access_token = create_access_token(identity=identity, expires_delta=expires)
         return jsonify(access_token=access_token), 200
     
     def register_user_controller(self, data):


### PR DESCRIPTION
### What does this PR do?
This PR sets up expiry for the json web token

#### How should this be manually tested?
- Fetch this branch `git fetch origin ft-setup-jwt-token-expiry-168682276`
- Checkout to this branch `git checkout ft-setup-jwt-token-expiry-168682276`
- Set up the virtual environment by running `virtualenv venv -p python3`
- Start the virtual environment `source venv/bin/activate`
- Run `pip install -r requirements.txt`
- Start the development server using `python run.py`
- Login a user  by making a POST to `api/v1/auth/login` in postman
- Sample request body
{
	"password": "1234Maria",
	"username": "mariah"
}
#### Screenshots
<img width="972" alt="Screen Shot 2019-09-21 at 4 26 31 PM" src="https://user-images.githubusercontent.com/39744587/65373927-9bdd1400-dc8c-11e9-95ca-515a13d919ca.png">

#### What are the relevant pivotal tracker stories?
[#168682276](https://www.pivotaltracker.com/story/show/168682276)

#### Run in postman
[![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/2863761324d0ccaa3661)