### PR TITLE
 #168697466: set up package type details by admin

### DIFF
--- a/api/controllers/package_controllers.py
+++ b/api/controllers/package_controllers.py
@@ -159,3 +159,23 @@ class PackageController:
                 "delivery_status": row[12]
             })
         return package
+    
+    def check_if_package_type_exists(self,data):
+        sql = """SELECT * FROM package_type WHERE package_type_name = '{}'"""
+        self.cur.execute(sql.format(data['package_type_name']))
+        row = self.cur.fetchone()
+        if row:
+            return True
+    
+    def create_package_type(self, data):
+        sql = """INSERT INTO package_type(package_type_name)VALUES('{}')"""
+        self.cur.execute(sql.format(data['package_type_name']))
+
+    def create_package_type_name(self, data):
+        is_valid = package_validate.validate_package_type(data)
+        if is_valid == "valid package type":
+            if not self.check_if_package_type_exists(data):
+                self.create_package_type(data)
+                return jsonify({"message": "Package type succesfully created"}), 201
+            return jsonify({"message": "Package already exists, try another"}), 400
+        return jsonify({"message": is_valid}), 400

--- a/api/validators/package_validators.py
+++ b/api/validators/package_validators.py
@@ -55,3 +55,11 @@ class PackageValidate:
         if isinstance(self.compare_dates(data), str):
             return self.compare_dates(data)
         return "valid package details"
+    
+    def validate_package_type(self, data):
+        """
+        Validates the package type field
+        """
+        if data['package_type_name'] == "":
+            return "package_type_name cannot be blank"
+        return "valid package type"

--- a/api/views/package_views.py
+++ b/api/views/package_views.py
@@ -84,3 +84,16 @@ def fetch_single_package(id):
             return jsonify({"package": single_package}), 200 
         return jsonify({"message": "Package doesnot exist"}), 404
     return jsonify({"message": "Permission denied, should be Admin"}), 401
+
+
+@package.route('/api/v1/packages/packagetype', methods=['POST'])
+@jwt_required
+def create_package_type():
+    """
+    Creates the package type in the package_type_table
+    """
+    data = request.get_json()
+    token = helper_controller.get_token_from_request()
+    if user_controller.check_user_permission(token) == 'Admin':
+        return package_controller.create_package_type_name(data)
+    return jsonify({"message": "Only Admins can create a package type"}), 401


### PR DESCRIPTION
### What does this PR do?
This PR allows the admin to create the package type
#### Description
- setup package type view
- limit permission to create and update the package type to only admin
#### How should this be manually tested?
- Fetch this branch `git fetch origin ft-setup-package-type-168697466`
- Checkout to this branch `git checkout ft-setup-package-type-168697466`
- Set up the virtual environment by running `virtualenv venv -p python3`
- Start the virtual environment `source venv/bin/activate`
- Run `pip install -r requirements.txt`
- Start the development server using `python run.py`
- Login as an Admin by making a POST to `api/v1/auth/login` in postman
- Obtain the token and the add it to the Authorization section in postman
- Run `api/v1/packages/packages/packagetype` in postman to create a package type name
- Sample request body
 `{
	"package_type_name": "Cereals"
}`

####  What are the relevant pivotal tracker stories?
[#168697466](https://www.pivotaltracker.com/story/show/ 168697466)

#### Run in postman
[![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/2863761324d0ccaa3661)